### PR TITLE
Feature: wish 페이지 개발

### DIFF
--- a/frontend/src/app/wish/[id]/page.tsx
+++ b/frontend/src/app/wish/[id]/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+import Card from '@/components/Card';
+
+import { CardProps } from '@/types/type';
+
+import Back from '../../../../public/svgs/back.svg';
+
+interface WishType {
+  id: number;
+  location: string;
+  count: number;
+}
+
+const wishData: WishType[] = [
+  {
+    id: 0,
+    location: '전체',
+    count: 11,
+  },
+  {
+    id: 1,
+    location: '강릉',
+    count: 0,
+  },
+  {
+    id: 2,
+    location: '경주',
+    count: 0,
+  },
+  {
+    id: 3,
+    location: '부산',
+    count: 0,
+  },
+  { id: 4, location: '여수', count: 0 },
+  {
+    id: 5,
+    location: '전주',
+    count: 0,
+  },
+  {
+    id: 6,
+    location: '제주',
+    count: 0,
+  },
+  {
+    id: 7,
+    location: '춘천',
+    count: 0,
+  },
+];
+
+export default function WishDetail() {
+  const pathname = usePathname();
+
+  const [wishItem, setWishItem] = useState<WishType>();
+
+  const [feedList, setFeedList] = useState<CardProps[]>([]);
+  useEffect(() => {
+    setFeedList([
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: false,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: false,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+      {
+        cardType: 'default',
+        serviceType: 'work',
+        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+        location: '파주시 중앙로 70 A동',
+        image: '/svgs/feed-test.svg',
+        price: 10000,
+        company: '홍익돈까스 파주금릉점',
+        inWishlist: true,
+      },
+    ]);
+  }, []);
+
+  useEffect(() => {
+    const id = pathname ? parseInt(pathname.split('/').pop() || '', 10) : null;
+
+    if (id !== null) {
+      const item = wishData.find(wish => wish.id === id);
+      setWishItem(item);
+    }
+  }, [pathname]);
+
+  return (
+    <div className="w-screen h-full flex justify-center text-black bg-white">
+      {wishItem && (
+        <div className="max-w-sm w-full h-full flex flex-col items-center relative pt-16">
+          <div className="max-w-sm w-full text-center py-3 px-5 flex items-center gap-3 fixed top-0 left-1/2	-translate-x-2/4 bg-white z-10">
+            <Link href="/wish">
+              <Back className="cursor-pointer" />
+            </Link>
+            <span>{wishItem.location}</span>
+          </div>
+          <div className="w-full flex flex-col px-6 items-center gap-2">
+            {feedList.map(item => (
+              <Card
+                cardType={item.cardType}
+                serviceType={item.serviceType}
+                title={item.title}
+                location={item.location}
+                image={item.image}
+                price={item.price}
+                company={item.company}
+                inWishlist={item.inWishlist}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/wish/[id]/page.tsx
+++ b/frontend/src/app/wish/[id]/page.tsx
@@ -158,8 +158,8 @@ export default function WishDetail() {
   return (
     <div className="w-screen h-full flex justify-center text-black bg-white">
       {wishItem && (
-        <div className="max-w-sm w-full h-full flex flex-col items-center relative pt-16">
-          <div className="max-w-sm w-full text-center py-3 px-5 flex items-center gap-3 fixed top-0 left-1/2	-translate-x-2/4 bg-white z-10">
+        <div className="max-w-sm w-full h-full flex flex-col items-center relative py-16">
+          <div className="max-w-sm w-full text-center pt-6 pb-2 px-5 flex items-center gap-3 fixed top-0 left-1/2	-translate-x-2/4 bg-white z-10">
             <Link href="/wish">
               <Back className="cursor-pointer" />
             </Link>

--- a/frontend/src/app/wish/[id]/page.tsx
+++ b/frontend/src/app/wish/[id]/page.tsx
@@ -166,8 +166,9 @@ export default function WishDetail() {
             <span>{wishItem.location}</span>
           </div>
           <div className="w-full flex flex-col px-6 items-center gap-2">
-            {feedList.map(item => (
+            {feedList.map((item, index) => (
               <Card
+                key={`card-${index}`}
                 cardType={item.cardType}
                 serviceType={item.serviceType}
                 title={item.title}

--- a/frontend/src/app/wish/page.tsx
+++ b/frontend/src/app/wish/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Back from '../../../public/svgs/back.svg';
+import Go from '../../../public/svgs/go.svg';
+
+interface WishType {
+  id: number;
+  location: string;
+  count: number;
+}
+
+export default function Wish() {
+  const [wishList, setWishList] = useState<WishType[]>([]);
+
+  useEffect(() => {
+    setWishList([
+      {
+        id: 0,
+        location: '전체',
+        count: 11,
+      },
+      {
+        id: 1,
+        location: '강릉',
+        count: 0,
+      },
+      {
+        id: 2,
+        location: '경주',
+        count: 0,
+      },
+      {
+        id: 3,
+        location: '부산',
+        count: 0,
+      },
+      { id: 4, location: '여수', count: 0 },
+      {
+        id: 5,
+        location: '전주',
+        count: 0,
+      },
+      {
+        id: 6,
+        location: '제주',
+        count: 0,
+      },
+      {
+        id: 7,
+        location: '춘천',
+        count: 0,
+      },
+    ]);
+  }, []);
+
+  return (
+    <div className="w-screen h-full flex justify-center text-black bg-white">
+      <div className="max-w-sm w-full h-full flex flex-col items-center gap-2">
+        <div className="w-full relative text-center py-3">
+          <Back className="absolute top-3 left-6 cursor-pointer" />
+          <span>위시리스트</span>
+        </div>
+        <div className="w-full flex flex-col px-6 items-center">
+          {wishList.map(item => (
+            <Link
+              href={`/wish/${item.id}`}
+              key={item.id}
+              passHref
+              className="w-full"
+            >
+              <div
+                className="w-full flex justify-between px-3 py-4 border-b"
+                role="button"
+                tabIndex={0}
+              >
+                <span>
+                  {item.location}({item.count})
+                </span>
+                <Go />
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/wish/page.tsx
+++ b/frontend/src/app/wish/page.tsx
@@ -57,7 +57,7 @@ export default function Wish() {
 
   return (
     <div className="w-screen h-full flex justify-center text-black bg-white">
-      <div className="max-w-sm w-full h-full flex flex-col items-center gap-2">
+      <div className="max-w-sm w-full h-full flex flex-col items-center gap-2 py-4">
         <div className="w-full relative text-center py-3">
           <Back className="absolute top-3 left-6 cursor-pointer" />
           <span>위시리스트</span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

> app/wish/page.tsx
> 각 지역 별 이름과 wish 수 표시 및 해당 지역 wish list 이동 기능
<img src="https://github.com/user-attachments/assets/52b2e169-54ff-40ea-bbed-e9a28d22fb59" width="200"/>

> app/wish/[id]/page.tsx
> 각 지역 id 에 맞는 wish 표시 페이지
<img src="https://github.com/user-attachments/assets/19cd6792-88f3-414b-a2db-a1d601001920" width="200"/>

## 💬리뷰 요구사항(선택)

> 디자인 - 마찬가지로 스크롤 되었을 때 디자인에 대한 말씀이 없으셔서 우선 헤더가 위에 보이도록 하였습니다.
> @jangsumi 검토해주시고 기획과 다르다면 바로 수정하도록 하겠습니다.
> <img src="https://github.com/user-attachments/assets/5f1a4d48-727e-4125-80fd-a7a30121b999" width="300"/>

> 디렉토리 구조 - id 를 통한 다이나믹 라우팅을 사용하려 했는데, 제대로 된 방식인지 검토 부탁드리겠습니다.
