### PR TITLE
Feature: next config 이미지 도메인 설정

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // 이미지 도메인 설정 추가
+  images: {
+    domains: ['tong.visitkorea.or.kr'],
+  },
+
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/frontend/src/components/Card/index.tsx
+++ b/frontend/src/components/Card/index.tsx
@@ -125,6 +125,7 @@ export default function Card({
           }
           width={serviceType === 'default' ? 0 : 80}
           height={serviceType === 'default' ? 0 : 80}
+          unoptimized
         />
       </ImageSection>
       <Content $cardType={cardType}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #76 

## 📝작업 내용

> next/Image가 외부 도메인을 허용하지 않는 이슈를 해결하기 위해 next config에 *tong.visitkorea.or.kr* 도메인을 허용하도록 설정했습니다.
> next/Image의 이미지 자동 최적화를 방지하기 위해 unoptimized 속성을 추가했습니다.
