### PR TITLE
Feature: spot, stay api 연동

### DIFF
--- a/frontend/src/app/(feed)/job/page.tsx
+++ b/frontend/src/app/(feed)/job/page.tsx
@@ -94,7 +94,7 @@ export default function Job() {
 
   return (
     <div className="w-full flex flex-col items-center gap-5 text-black">
-      <div className="flex flex-col gap-1 items-center">
+      <div className="flex flex-col gap-1 items-center w-full">
         {feedList.map(item => (
           <Card
             cardType={item.cardType}

--- a/frontend/src/app/(feed)/layout.tsx
+++ b/frontend/src/app/(feed)/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 
 import Input from '@/components/Input';
@@ -13,15 +14,31 @@ interface Props {
 }
 
 export default function FeedLayout({ children }: Props) {
+  const pathname = usePathname();
+  const [mapClick, setMapClick] = useState<() => void>(() => () => {});
+
   const leftClick = () => {
     console.log('leftClick');
   };
   const rightClick = () => {
     console.log('rightClick');
   };
-  const mapClick = () => {
-    console.log('mapClick');
-  };
+  // pathname에 따라 mapClick 함수 다르게 설정
+  useEffect(() => {
+    if (pathname === '/stay') {
+      setMapClick(() => () => {
+        console.log('mapClick : stay');
+      });
+    } else if (pathname === '/tour') {
+      setMapClick(() => () => {
+        console.log('mapClick : tour');
+      });
+    } else {
+      setMapClick(() => () => {
+        console.log('mapClick : job');
+      });
+    }
+  }, [pathname]);
 
   return (
     <div className="flex flex-col justify-start items-center h-full bg-white relative">

--- a/frontend/src/app/(feed)/stay/page.tsx
+++ b/frontend/src/app/(feed)/stay/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
 import Card from '@/components/Card';
 
 import { FeedProps } from '@/types/type';
@@ -9,19 +11,20 @@ import PublicAxiosInstance from '@/services/publicAxiosInstance';
 
 export default function Stay() {
   const [feedList, setFeedList] = useState<FeedProps[]>([]);
+  const router = useRouter();
+
   const fetchData = async () => {
     try {
       const response = await PublicAxiosInstance.get('/stays');
-      const data = response.data.data.map((item: any) => ({
+      console.log('response : ', response.data.data);
+      const data = response.data.data.map((item: FeedProps) => ({
         id: item.contentid,
         cardType: 'default',
         serviceType: 'default',
         title: item.title,
         location: `${item.addr1} ${item.addr2}`,
-        // image: item.firstimage || '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
-        image: '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
-        price: 0, // 가격 정보가 없으므로 기본값 설정
-        company: item.tel || '정보 없음', // 회사 또는 전화번호
+        image: item.firstimage || item.firstimage2 || '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
+        // image: '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
         inWishlist: false,
       }));
       setFeedList(data);
@@ -31,112 +34,30 @@ export default function Stay() {
   };
   useEffect(() => {
     fetchData();
-
-    // setFeedList([
-    //   {
-    //     id: 1,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: false,
-    //   },
-    //   {
-    //     id: 2,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    //   {
-    //     id: 3,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    //   {
-    //     id: 4,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    //   {
-    //     id: 5,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: false,
-    //   },
-    //   {
-    //     id: 6,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    //   {
-    //     id: 7,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    //   {
-    //     id: 8,
-    //     cardType: 'default',
-    //     serviceType: 'default',
-    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-    //     location: '파주시 중앙로 70 A동',
-    //     image: '/svgs/feed-test.svg',
-    //     price: 10000,
-    //     company: '홍익돈까스 파주금릉점',
-    //     inWishlist: true,
-    //   },
-    // ]);
   }, []);
+
+  const cardClick = id => {
+    router.push(`/stay/${id}`);
+  };
+
+  const wishClick = () => {
+    console.log('wishClick');
+  };
 
   return (
     <div className="w-full flex flex-col items-center gap-5 text-black">
       <div className="flex flex-col gap-1 items-center">
         {feedList.map(item => (
           <Card
+            id={item.contentid}
             cardType={item.cardType}
             serviceType={item.serviceType}
             title={item.title}
             location={item.location}
             image={item.image}
-            price={item.price}
-            company={item.company}
             inWishlist={item.inWishlist}
+            onCardClick={() => cardClick(item.contentid)}
+            onWishListClick={wishClick}
           />
         ))}
       </div>

--- a/frontend/src/app/(feed)/stay/page.tsx
+++ b/frontend/src/app/(feed)/stay/page.tsx
@@ -3,93 +3,125 @@
 import { useEffect, useState } from 'react';
 import Card from '@/components/Card';
 
-import { CardProps } from '@/types/type';
+import { FeedProps } from '@/types/type';
+
+import PublicAxiosInstance from '@/services/publicAxiosInstance';
 
 export default function Stay() {
-  const [feedList, setFeedList] = useState<CardProps[]>([]);
+  const [feedList, setFeedList] = useState<FeedProps[]>([]);
+  const fetchData = async () => {
+    try {
+      const response = await PublicAxiosInstance.get('/stays');
+      const data = response.data.data.map((item: any) => ({
+        id: item.contentid,
+        cardType: 'default',
+        serviceType: 'default',
+        title: item.title,
+        location: `${item.addr1} ${item.addr2}`,
+        // image: item.firstimage || '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
+        image: '/svgs/feed-test.svg', // 이미지가 없을 경우 기본 이미지 사용
+        price: 0, // 가격 정보가 없으므로 기본값 설정
+        company: item.tel || '정보 없음', // 회사 또는 전화번호
+        inWishlist: false,
+      }));
+      setFeedList(data);
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+  };
   useEffect(() => {
-    setFeedList([
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: false,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: false,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-      {
-        cardType: 'default',
-        serviceType: 'default',
-        title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
-        location: '파주시 중앙로 70 A동',
-        image: '/svgs/feed-test.svg',
-        price: 10000,
-        company: '홍익돈까스 파주금릉점',
-        inWishlist: true,
-      },
-    ]);
+    fetchData();
+
+    // setFeedList([
+    //   {
+    //     id: 1,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: false,
+    //   },
+    //   {
+    //     id: 2,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    //   {
+    //     id: 3,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    //   {
+    //     id: 4,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    //   {
+    //     id: 5,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: false,
+    //   },
+    //   {
+    //     id: 6,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    //   {
+    //     id: 7,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    //   {
+    //     id: 8,
+    //     cardType: 'default',
+    //     serviceType: 'default',
+    //     title: '홍익돈까스 주6일 주방 정직원 모집 시간 협의 가능',
+    //     location: '파주시 중앙로 70 A동',
+    //     image: '/svgs/feed-test.svg',
+    //     price: 10000,
+    //     company: '홍익돈까스 파주금릉점',
+    //     inWishlist: true,
+    //   },
+    // ]);
   }, []);
 
   return (

--- a/frontend/src/app/(feed)/tour/page.tsx
+++ b/frontend/src/app/(feed)/tour/page.tsx
@@ -9,7 +9,7 @@ import { FeedProps } from '@/types/type';
 
 import PublicAxiosInstance from '@/services/publicAxiosInstance';
 
-export default function Stay() {
+export default function Tour() {
   const [feedList, setFeedList] = useState<FeedProps[]>([]);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
@@ -18,11 +18,11 @@ export default function Stay() {
   const router = useRouter();
 
   const fetchData = async () => {
-    if (loading || !hasMore) return; // 이미 데이터를 불러오고 있거나 더 이상 데이터가 없으면 종료
+    if (loading || !hasMore) return;
     setLoading(true);
 
     try {
-      const response = await PublicAxiosInstance.get(`/stays?page=${page}`);
+      const response = await PublicAxiosInstance.get(`/spots?page=${page}`);
       const data = response.data.data.map((item: FeedProps) => ({
         contentId: item.contentId,
         cardType: 'default',

--- a/frontend/src/services/privateAxiosInstance.ts
+++ b/frontend/src/services/privateAxiosInstance.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const PrivateAxiosInstance = axios.create({
-  baseURL: process.env.NEXT_BULIC_API_BASE_URI,
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URI,
   timeout: 1000,
   headers: { 'Content-Type': 'application/json' },
 });

--- a/frontend/src/services/publicAxiosInstance.ts
+++ b/frontend/src/services/publicAxiosInstance.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const PublicAxiosInstance = axios.create({
-  baseURL: process.env.NEXT_BULIC_API_BASE_URI,
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URI,
   timeout: 1000,
   headers: { 'Content-Type': 'application/json' },
 });

--- a/frontend/src/types/type.ts
+++ b/frontend/src/types/type.ts
@@ -25,3 +25,15 @@ export interface BannerProps {
   description: string;
   backgroundImage: React.ReactNode;
 }
+
+export interface FeedProps {
+  id?: number;
+  cardType: CardType;
+  serviceType: ServiceType;
+  title: string;
+  location: string;
+  image: string;
+  price: number;
+  company: string;
+  inWishlist: boolean;
+}

--- a/frontend/src/types/type.ts
+++ b/frontend/src/types/type.ts
@@ -8,7 +8,7 @@ export interface CardProps {
   title: string;
   location: string;
   image: string;
-  price: number;
+  price?: number;
   onCardClick: React.MouseEventHandler<HTMLDivElement>;
   onWishListClick: (id: number) => void;
   inWishlist?: boolean;
@@ -27,13 +27,16 @@ export interface BannerProps {
 }
 
 export interface FeedProps {
-  contentid: number;
+  contentId: number;
   cardType: CardType;
   serviceType: ServiceType;
   title: string;
+  firstimage: string;
+  firstimage2: string;
   addr1: string;
   addr2: string;
-  location: string;
   image: string;
   inWishlist: boolean;
+  location: string;
 }
+// job 같은 경우에는 아직 안나와서 추후에 추가 예정

--- a/frontend/src/types/type.ts
+++ b/frontend/src/types/type.ts
@@ -27,13 +27,13 @@ export interface BannerProps {
 }
 
 export interface FeedProps {
-  id?: number;
+  contentid: number;
   cardType: CardType;
   serviceType: ServiceType;
   title: string;
+  addr1: string;
+  addr2: string;
   location: string;
   image: string;
-  price: number;
-  company: string;
   inWishlist: boolean;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #78 

## 📝작업 내용

> app/(feed)/layout.tsx
- 레이아웃 : 지도 이동 버튼
- pathname 에 따라서 다르게 동작하도록 함수 정의

> app/(feed)/tour/page.tsx, app/(feed)/stay/page.tsx
- 각 페이지 api 연동
- 무한 스크롤 기능 추가를 위해 스크롤 감지 및 페이지네이션 적용
- 각 Card 클릭 시 해당 item 의 contentId 를 통해 detail 페이지로 이동

> src/types/type.ts
- Feed Interface 추가
